### PR TITLE
Add new words to cSpell dictionary and update

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,7 @@
 {
     "cSpell.words": [
-        "Ashraf"
+        "ahmedashraf",
+        "Ashraf",
+        "Laravel"
     ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 All notable changes to `laravel-eloquent-state-machines` will be documented in this file
+## v6.0.0 - 2023-11-17
+- Removed all the pending transition logic (***Breaking Change***)
+- Introduced new Closure function validation for transition hooks. By @ahmedashraf093
+- Added `->availableTransitions()` method to get all available transitions for `responsible` for a `model`. By @ahmedashraf093
 
 ## v5.1.0 - 2022-02-17
 

--- a/src/LaravelEloquentStateMachinesServiceProvider.php
+++ b/src/LaravelEloquentStateMachinesServiceProvider.php
@@ -12,7 +12,6 @@ class LaravelEloquentStateMachinesServiceProvider extends ServiceProvider
         if ($this->app->runningInConsole()) {
             $this->publishes([
                 __DIR__ . '/../database/migrations/create_state_histories_table.php.stub' => database_path('migrations/' . date('Y_m_d_His', time()) . '_create_state_histories_table.php'),
-                __DIR__ . '/../database/migrations/create_pending_transitions_table.php.stub' => database_path('migrations/' . date('Y_m_d_His', time()) . '_create_pending_transitions_table.php'),
             ], 'migrations');
 
             $this->commands([

--- a/src/StateMachines/State.php
+++ b/src/StateMachines/State.php
@@ -3,6 +3,7 @@
 
 namespace Ashraf\EloquentStateMachine\StateMachines;
 
+use Ashraf\EloquentStateMachine\Models\StateHistory;
 use Carbon\Carbon;
 
 /**
@@ -79,7 +80,7 @@ class State
 
 
 
-    public function transitionTo($state, $customProperties = [], $responsible = null)
+    public function transitionTo(string $state, mixed $customProperties = [], mixed $responsible = null)
     {
         $this->stateMachine->transitionTo(
             $from = $this->state,

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -31,7 +31,6 @@ class TestCase extends BaseTestCase
     protected function getEnvironmentSetUp($app)
     {
         include_once __DIR__ . '/../database/migrations/create_state_histories_table.php.stub';
-        include_once __DIR__ . '/../database/migrations/create_pending_transitions_table.php.stub';
 
         include_once __DIR__ . '/database/migrations/create_sales_orders_table.php';
         include_once __DIR__ . '/database/migrations/create_sales_managers_table.php';


### PR DESCRIPTION
- Removed all the pending transition logic (***Breaking Change***)
- Introduced new Closure function validation for transition hooks. By @ahmedashraf093
- Added `->availableTransitions()` method to get all available transitions for `responsible` for a `model`. By @ahmedashraf093

## Summary

Introduce entalirly new apis to the old asantibanez state machine

## Issue

[If exists, provide a link to the corresponding issue(s).]

## Type of Change

- [ ] :rocket: New Feature
- [x] :bug: Bug Fix
- [x] :hammer: Refactor
- [ ] :question: [Other]

## Screenshot/Video

[Provide a screenshot or video that describes the change if applicable]
